### PR TITLE
Fix: TextContext doesnt crash after other instance call. Add Children…

### DIFF
--- a/w19_memecreator/MainWindow.xaml.cs
+++ b/w19_memecreator/MainWindow.xaml.cs
@@ -26,9 +26,6 @@ namespace w19_memecreator {
         TextKontext textWindow = new TextKontext();
         EffektKontext effectWindow = new EffektKontext();
 
-
-
-
         public MainWindow()
         {
             InitializeComponent();
@@ -157,7 +154,11 @@ namespace w19_memecreator {
             
             // Index von Label in Canvas-Kind-Array in globale Variable nummerKind
             nummerKind = (int)label.Tag;
+
+
+            grid_Kontextfenster.Children.Clear();
             drawTextContext();
+            
         }
 
         private void LabelNummerLaden(object sender, RoutedEventArgs e)
@@ -174,12 +175,14 @@ namespace w19_memecreator {
         //Code Yannic
         public void drawTextContext()
         {
-            // TODO: if drawn == true
-            textWindow.set_targetLbl((Label)canvas_Bearbeitungsfenster.Children[nummerKind]);
-            grid_Kontextfenster.Children.Add(textWindow.get_btn_txtField_Apply());
-            grid_Kontextfenster.Children.Add(textWindow.get_cmBox_fontMenu());
-            grid_Kontextfenster.Children.Add(textWindow.get_cmBox_fontSize());
-            grid_Kontextfenster.Children.Add(textWindow.get_txtField_Text());
+
+                textWindow.set_targetLbl((Label)canvas_Bearbeitungsfenster.Children[nummerKind]);
+                grid_Kontextfenster.Children.Add(textWindow.get_btn_txtField_Apply());
+                grid_Kontextfenster.Children.Add(textWindow.get_cmBox_fontMenu());
+                grid_Kontextfenster.Children.Add(textWindow.get_cmBox_fontSize());
+                grid_Kontextfenster.Children.Add(textWindow.get_txtField_Text());
+
+            
         }
 
         public void drawEffectContext()


### PR DESCRIPTION
….Clear() before each drawXXXContext call.